### PR TITLE
Add support for Linux, global python installations, and loading python scripts from assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 obj
 *.user
 *.suo
+.bak

--- a/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
+++ b/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
@@ -5,7 +5,8 @@
     <Description>Bonsai Scripting Library for interfacing with the Python runtime.</Description>
     <PackageTags>Bonsai Rx Scripting Python Python.NET</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
+++ b/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
@@ -5,13 +5,13 @@
     <Description>Bonsai Scripting Library for interfacing with the Python runtime.</Description>
     <PackageTags>Bonsai Rx Scripting Python Python.NET</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.7.0" />
-    <PackageReference Include="pythonnet" Version="3.0.1" />
+    <PackageReference Include="pythonnet" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -175,13 +175,7 @@ namespace Bonsai.Scripting.Python
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + systemPath;
-                Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
-                // Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(Path.PathSeparator.ToString(),
-                //     path,
-                //     Path.Combine(pythonHome, $"python{pythonVersion}.zip"),
-                //     Path.Combine(pythonHome, "DLLs"),
-                //     Path.Combine(pythonHome, "Lib"),
-                //     Path.Combine(pythonHome, "Lib", "site-packages")), EnvironmentVariableTarget.Process);   
+                Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process); 
             }
             else
             {

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -188,5 +188,15 @@ namespace Bonsai.Scripting.Python
 
             return pythonPath;
         }
+
+        public static void SetEnvironmentPath(string pythonHome)
+        {
+                var systemPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
+                if (!systemPath.Split(Path.PathSeparator).Contains(pythonHome, StringComparer.OrdinalIgnoreCase))
+                {
+                    systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + systemPath;
+                }
+                Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
+        }
     }
 }

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -2,19 +2,43 @@
 using System.IO;
 using System.Linq;
 using Python.Runtime;
+using System.Runtime.InteropServices;
 
 namespace Bonsai.Scripting.Python
 {
     static class EnvironmentHelper
     {
-        public static string GetPythonDLL(string path)
+        public static string GetPythonDLL(string pythonHome, string path)
         {
+            string searchPath = pythonHome;
+            string searchPattern;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                pythonVersion = pythonVersion.Replace(".", "");
+                searchPattern = $"python{pythonVersion}*";
+            }
+            else 
+            {
+                searchPath = Path.Combine(searchPath, $"../lib/python{pythonVersion}");
+                searchPattern = $"libpython{pythonVersion}.so";
+            }
+
+            Console.WriteLine($"Search path: {searchPath}");
+            Console.WriteLine($"Search pattern: {searchPattern}");
+
             return Directory
-                .EnumerateFiles(path, searchPattern: "python3?*.*")
+                .EnumerateFiles(searchPath, searchPattern, SearchOption.AllDirectories)
                 .Select(Path.GetFileNameWithoutExtension)
-                .Where(match => match.Length > "python3".Length)
+                .Where(match => match.StartsWith($"python{pythonVersion}") || match.StartsWith($"libpython{pythonVersion}"))
                 .Select(match => match.Replace(".", string.Empty))
                 .FirstOrDefault();
+            // return Directory
+            //     .EnumerateFiles(pythonHome, searchPattern: "python3?*.*")
+            //     .Select(Path.GetFileNameWithoutExtension)
+            //     .Where(match => match.Length > "python3".Length)
+            //     .Select(match => match.Replace(".", string.Empty))
+            //     .FirstOrDefault();
         }
 
         public static void SetRuntimePath(string pythonHome)
@@ -40,24 +64,86 @@ namespace Bonsai.Scripting.Python
                     }
                 }
             }
-
             return path;
+        }
+
+        public static string GetPythonVersionFromVenv(string path)
+        {
+            var configFileName = Path.Combine(path, "pyvenv.cfg");
+            if (File.Exists(configFileName))
+            {
+                using var configReader = new StreamReader(File.OpenRead(configFileName));
+                while (!configReader.EndOfStream)
+                {
+                    var line = configReader.ReadLine();
+                    if (line.StartsWith("version"))
+                    {
+                        var parts = line.Split('=')[1].Trim().Split('.');
+                        return $"{parts[0]}.{parts[1]}";
+                    }
+                }
+            }
+            return "";
+        }
+
+        public static string GetPythonVersionFromPythonDir(string pythonHome)
+        {
+            var pythonExecutableRegex = new Regex(@"python3(\d+)?(\.\d+)?", RegexOptions.IgnoreCase);
+            var highestVersion = "0.0";
+            
+            var filesAndDirs = Directory.EnumerateFileSystemEntries(pythonHome);
+            foreach (var entry in filesAndDirs)
+            {
+                var name = Path.GetFileName(entry);
+                var match = pythonExecutableRegex.Match(name);
+                if (match.Success)
+                {
+                    var version = match.Value.Replace("python", "").Replace("Python", "");
+                    if (String.Compare(version, highestVersion) > 0)
+                    {
+                        highestVersion = version;
+                    }
+                }
+            }
+
+            return highestVersion != "0.0" ? highestVersion : null;
         }
 
         public static string GetPythonPath(string pythonHome, string path)
         {
             var basePath = PythonEngine.PythonPath;
-            if (string.IsNullOrEmpty(basePath))
+            var pythonVersion = GetPythonVersion(path);
+            var sitePackages = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Path.Combine(path, "Lib", "site-packages") :
+                string.Join(Path.PathSeparator.ToString(), Path.Combine(path, "lib", $"python{pythonVersion}", "site-packages"), 
+                    Path.Combine(path, "lib64", $"python{pythonVersion}", "site-packages"));
+            if (string.IsNullOrEmpty(PythonEngine.PythonPath))
             {
-                var pythonZip = Path.Combine(pythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
-                var pythonDLLs = Path.Combine(pythonHome, "DLLs");
-                var pythonLib = Path.Combine(pythonHome, "Lib");
-                var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var pythonZip = Path.Combine(pythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
+                    var pythonDLLs = Path.Combine(pythonHome, "DLLs");
+                    var pythonLib = Path.Combine(pythonHome, "Lib");
+                    var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                    basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
+                }
+                else
+                {
+                    var pythonLib = Path.Combine(pythonHome, $"../lib/python{pythonVersion}");
+                    var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                    basePath = string.Join(Path.PathSeparator.ToString(), pythonLib, baseDirectory);
+                }
             }
 
-            var sitePackages = Path.Combine(path, "Lib", "site-packages");
-            return $"{basePath}{Path.PathSeparator}{path}{Path.PathSeparator}{sitePackages}";
+            // var sitePackages = Path.Combine(path, "Lib", "site-packages");
+            // var newPath = $"{basePath}{Path.PathSeparator}{path}{Path.PathSeparator}{sitePackages}";
+
+            var newPath = string.Join(
+                Path.PathSeparator.ToString(), 
+                path,
+                basePath,
+                sitePackages
+            );
+            return newPath;
         }
     }
 }

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -3,13 +3,17 @@ using System.IO;
 using System.Linq;
 using Python.Runtime;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace Bonsai.Scripting.Python
 {
     static class EnvironmentHelper
     {
-        public static string GetPythonDLL(string pythonHome, string path)
+        public static string GetPythonDLL(string pythonHome, string path, string pythonVersion)
         {
+            // string pythonVersion = GetPythonVersion(path);
+            // if string.IsNullOrEmpty(pythonVersion) pythonVersion = GetPythonVersionFrom(pythonHome);
+
             string searchPath = pythonHome;
             string searchPattern;
 
@@ -109,10 +113,10 @@ namespace Bonsai.Scripting.Python
             return highestVersion != "0.0" ? highestVersion : null;
         }
 
-        public static string GetPythonPath(string pythonHome, string path)
+        public static string GetPythonPath(string pythonHome, string path, string pythonVersion)
         {
             var basePath = PythonEngine.PythonPath;
-            var pythonVersion = GetPythonVersion(path);
+            // var pythonVersion = GetPythonVersion(path);
             var sitePackages = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Path.Combine(path, "Lib", "site-packages") :
                 string.Join(Path.PathSeparator.ToString(), Path.Combine(path, "lib", $"python{pythonVersion}", "site-packages"), 
                     Path.Combine(path, "lib64", $"python{pythonVersion}", "site-packages"));

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using Python.Runtime;
@@ -24,7 +25,6 @@ namespace Bonsai.Scripting.Python
             Schedule(() =>
             {
                 Initialize(pythonHome);
-                Console.WriteLine("Initialized");
                 threadState = PythonEngine.BeginAllowThreads();
                 using (Py.GIL())
                 {
@@ -77,36 +77,59 @@ namespace Bonsai.Scripting.Python
 
         static void Initialize(string path)
         {
+            Console.WriteLine($"Python engine initialized? {PythonEngine.IsInitialized}.");
             if (!PythonEngine.IsInitialized)
             {
+                Console.WriteLine($"Starting path: {path}");
                 if (string.IsNullOrEmpty(path))
                 {
                     path = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                    if (string.IsNullOrEmpty(path)) path = Environment.CurrentDirectory;
+                    Console.WriteLine($"Virtual env path: {path}");
                 }
 
-                path = Path.GetFullPath(path);
-                Console.WriteLine($"Path: {path}");
+                if (!string.IsNullOrEmpty(path))
+                {
+                    path = Path.GetFullPath(path);
+                    Console.WriteLine($"Base Path: {path}");
+                }
 
                 var pythonHome = EnvironmentHelper.GetPythonHome(path);
                 Console.WriteLine($"Python Home: {pythonHome}");
 
-                var pythonVersion = EnvironmentHelper.GetPythonVersionFromVenv(path);
-                if (string.IsNullOrEmpty(pythonVersion)) pythonVersion = EnvironmentHelper.GetPythonVersionFromPythonDir(pythonHome);
+                var pythonVersion = EnvironmentHelper.GetPythonVersion(path, pythonHome);
                 Console.WriteLine($"Python Version: {pythonVersion}");
-                
-                var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, path, pythonVersion);
+
+                var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonVersion);
                 Console.WriteLine($"Python DLL: {pythonDLL}");
                 Runtime.PythonDLL = pythonDLL;
 
-                EnvironmentHelper.SetRuntimePath(pythonHome);
+                // var systemPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
+                // if (!systemPath.Split(Path.PathSeparator).Contains(pythonHome, StringComparer.OrdinalIgnoreCase))
+                // {
+                //     systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + path;
+                // }
+                // Console.WriteLine($"System Path: {systemPath}");
+                // Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
+
                 PythonEngine.PythonHome = pythonHome;
+
+                // Console.WriteLine($"Python Engine Path: {PythonEngine.PythonPath}");
+
                 if (pythonHome != path)
                 {
-                    var version = PythonEngine.Version;
-                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, pythonVersion);
+                    var pythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, pythonVersion);
+                    Console.WriteLine($"Python Path: {pythonPath}");
+                    PythonEngine.PythonPath = pythonPath;
                 }
+
+                Console.WriteLine($"Python engine python path: {PythonEngine.PythonPath}");
+                Console.WriteLine($"Python engine build info: {PythonEngine.BuildInfo}");
+
+                Console.WriteLine("Initializing python engine...");
                 PythonEngine.Initialize();
+
+                Console.WriteLine($"Python engine python home: {PythonEngine.PythonHome}");
+                Console.WriteLine($"Python engine version: {PythonEngine.Version}");
             }
         }
 
@@ -127,6 +150,7 @@ namespace Bonsai.Scripting.Python
                             MainModule.Dispose();
                         }
                     }
+                    Console.WriteLine("Shutting down...");
                     PythonEngine.EndAllowThreads(threadState);
                     PythonEngine.Shutdown();
                 }

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -113,68 +113,28 @@ namespace Bonsai.Scripting.Python
         {
             if (!PythonEngine.IsInitialized)
             {
-                // string venvPath = null;
-                // if (string.IsNullOrEmpty(path))
-                // {
-                //     venvPath = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                //     path = venvPath;
-                // }
                 path = EnvironmentHelper.GetVirtualEnvironmentPath(path);
                 EnvironmentHelper.SetVirtualEnvironmentPath(path);
 
-                Console.WriteLine($"Path: {path}");
-
                 var pythonHome = EnvironmentHelper.GetPythonHome(path);
-                Console.WriteLine($"Python home: {pythonHome}");
-
                 var pythonVersion = EnvironmentHelper.GetPythonVersion(path, pythonHome);
-                Console.WriteLine($"Python version: {pythonVersion}");
-
                 var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, pythonVersion);
-                Console.WriteLine($"Python dll: {pythonDLL}");
 
-                // Set the python DLL
                 Runtime.PythonDLL = pythonDLL;
                 
                 // Only set environment/python.net variables if a virtual environment is used, otherwise use default python configuration
                 if (!string.IsNullOrEmpty(path))
                 {
-                    // var pathToVirtualEnv = Path.GetFullPath(path);
-                    // Console.WriteLine($"Venv path: {pathToVirtualEnv}");
 
-                    // if (string.IsNullOrEmpty(venvPath))
-                    // {
-                    //     Environment.SetEnvironmentVariable("VIRTUAL_ENV", pathToVirtualEnv);
-                    //     // var virtualEnvPrompt = $"({Path.GetFileName(pathToVirtualEnv)})";
-                    //     // Environment.SetEnvironmentVariable("VIRTUAL_ENV_PROMPT", virtualEnvPrompt);
-                    //     // var ps1 = Environment.GetEnvironmentVariable("PS1");
-                    //     // ps1 = string.IsNullOrEmpty(ps1) ? virtualEnvPrompt : virtualEnvPrompt + " " + ps1;
-                    //     // Environment.SetEnvironmentVariable("PS1", ps1);
-                    // }
                     EnvironmentHelper.SetRuntimePath(pythonHome, path, pythonVersion);
                     PythonEngine.PythonHome = pythonHome;
-                    // string systemPath = Environment.GetEnvironmentVariable("PATH")!.TrimEnd(Path.PathSeparator);
-                    // systemPath = string.IsNullOrEmpty(systemPath) ? $"{pathToVirtualEnv}/bin" : $"{pathToVirtualEnv}/bin" + Path.PathSeparator + systemPath;
-                    // Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
-                    // Environment.SetEnvironmentVariable("PYTHONHOME", pathToVirtualEnv, EnvironmentVariableTarget.Process);
-                    // var pythonBase = Path.GetDirectoryName(pythonHome);
-                    // Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(Path.PathSeparator.ToString(),
-                    //     pathToVirtualEnv,
-                    //     $"{pythonBase}/lib/python{pythonVersion}.zip",
-                    //     $"{pythonBase}/lib/python{pythonVersion}",
-                    //     $"{pythonBase}/lib/python{pythonVersion}/lib-dynload",
-                    //     $"{pathToVirtualEnv}/lib/python{pythonVersion}/site-packages"), EnvironmentVariableTarget.Process);
 
                     if (pythonHome != path)
                     {
                         var basePath = PythonEngine.PythonPath;
                         var pythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, basePath, pythonDLL);
-                        // PythonEngine.PythonPath = PythonEngine.PythonPath + Path.PathSeparator +
-                        //     Environment.GetEnvironmentVariable("PYTHONPATH", EnvironmentVariableTarget.Process);
                         PythonEngine.PythonPath = pythonPath;
                     }
-                    // PythonEngine.PythonHome = path;
-                    // PythonEngine.PythonHome = pythonHome;
                 }
 
                 PythonEngine.Initialize();

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -93,8 +93,9 @@ namespace Bonsai.Scripting.Python
 
                 var pythonVersion = EnvironmentHelper.GetPythonVersionFromVenv(path);
                 if (string.IsNullOrEmpty(pythonVersion)) pythonVersion = EnvironmentHelper.GetPythonVersionFromPythonDir(pythonHome);
+                Console.WriteLine($"Python Version: {pythonVersion}");
                 
-                var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, path);
+                var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, path, pythonVersion);
                 Console.WriteLine($"Python DLL: {pythonDLL}");
                 Runtime.PythonDLL = pythonDLL;
 
@@ -103,7 +104,7 @@ namespace Bonsai.Scripting.Python
                 if (pythonHome != path)
                 {
                     var version = PythonEngine.Version;
-                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path);
+                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, pythonVersion);
                 }
                 PythonEngine.Initialize();
             }

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -77,59 +77,37 @@ namespace Bonsai.Scripting.Python
 
         static void Initialize(string path)
         {
-            Console.WriteLine($"Python engine initialized? {PythonEngine.IsInitialized}.");
             if (!PythonEngine.IsInitialized)
             {
-                Console.WriteLine($"Starting path: {path}");
                 if (string.IsNullOrEmpty(path))
                 {
                     path = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                    Console.WriteLine($"Virtual env path: {path}");
                 }
 
                 if (!string.IsNullOrEmpty(path))
                 {
                     path = Path.GetFullPath(path);
-                    Console.WriteLine($"Base Path: {path}");
                 }
 
                 var pythonHome = EnvironmentHelper.GetPythonHome(path);
-                Console.WriteLine($"Python Home: {pythonHome}");
-
                 var pythonVersion = EnvironmentHelper.GetPythonVersion(path, pythonHome);
-                Console.WriteLine($"Python Version: {pythonVersion}");
-
                 var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonVersion);
-                Console.WriteLine($"Python DLL: {pythonDLL}");
                 Runtime.PythonDLL = pythonDLL;
-
+                // EnvironmentHelper.SetEnvironmentPath(pythonHome);
                 var systemPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
                 if (!systemPath.Split(Path.PathSeparator).Contains(pythonHome, StringComparer.OrdinalIgnoreCase))
                 {
-                    systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + path;
+                    systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + systemPath;
                 }
-                Console.WriteLine($"System Path: {systemPath}");
                 Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
-
                 PythonEngine.PythonHome = pythonHome;
-
-                // Console.WriteLine($"Python Engine Path: {PythonEngine.PythonPath}");
-
                 if (pythonHome != path)
                 {
                     var pythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, pythonVersion);
-                    Console.WriteLine($"Python Path: {pythonPath}");
                     PythonEngine.PythonPath = pythonPath;
                 }
 
-                Console.WriteLine($"Python engine python path: {PythonEngine.PythonPath}");
-                Console.WriteLine($"Python engine build info: {PythonEngine.BuildInfo}");
-
-                Console.WriteLine("Initializing python engine...");
                 PythonEngine.Initialize();
-
-                Console.WriteLine($"Python engine python home: {PythonEngine.PythonHome}");
-                Console.WriteLine($"Python engine version: {PythonEngine.Version}");
             }
         }
 
@@ -150,7 +128,6 @@ namespace Bonsai.Scripting.Python
                             MainModule.Dispose();
                         }
                     }
-                    Console.WriteLine("Shutting down...");
                     PythonEngine.EndAllowThreads(threadState);
                     PythonEngine.Shutdown();
                 }

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -24,6 +24,7 @@ namespace Bonsai.Scripting.Python
             Schedule(() =>
             {
                 Initialize(pythonHome);
+                Console.WriteLine("Initialized");
                 threadState = PythonEngine.BeginAllowThreads();
                 using (Py.GIL())
                 {
@@ -85,8 +86,18 @@ namespace Bonsai.Scripting.Python
                 }
 
                 path = Path.GetFullPath(path);
+                Console.WriteLine($"Path: {path}");
+
                 var pythonHome = EnvironmentHelper.GetPythonHome(path);
-                Runtime.PythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome);
+                Console.WriteLine($"Python Home: {pythonHome}");
+
+                var pythonVersion = EnvironmentHelper.GetPythonVersionFromVenv(path);
+                if (string.IsNullOrEmpty(pythonVersion)) pythonVersion = EnvironmentHelper.GetPythonVersionFromPythonDir(pythonHome);
+                
+                var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, path);
+                Console.WriteLine($"Python DLL: {pythonDLL}");
+                Runtime.PythonDLL = pythonDLL;
+
                 EnvironmentHelper.SetRuntimePath(pythonHome);
                 PythonEngine.PythonHome = pythonHome;
                 if (pythonHome != path)

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -113,23 +113,25 @@ namespace Bonsai.Scripting.Python
         {
             if (!PythonEngine.IsInitialized)
             {
-                string venvPath = null;
-                if (string.IsNullOrEmpty(path))
-                {
-                    venvPath = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                    path = venvPath;
-                }
+                // string venvPath = null;
+                // if (string.IsNullOrEmpty(path))
+                // {
+                //     venvPath = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
+                //     path = venvPath;
+                // }
+                path = EnvironmentHelper.GetVirtualEnvironmentPath(path);
+                EnvironmentHelper.SetVirtualEnvironmentPath(path);
 
-                // Console.WriteLine($"Path: {path}");
+                Console.WriteLine($"Path: {path}");
 
                 var pythonHome = EnvironmentHelper.GetPythonHome(path);
-                // Console.WriteLine($"Python home: {pythonHome}");
+                Console.WriteLine($"Python home: {pythonHome}");
 
                 var pythonVersion = EnvironmentHelper.GetPythonVersion(path, pythonHome);
-                // Console.WriteLine($"Python version: {pythonVersion}");
+                Console.WriteLine($"Python version: {pythonVersion}");
 
                 var pythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome, pythonVersion);
-                // Console.WriteLine($"Python dll: {pythonDLL}");
+                Console.WriteLine($"Python dll: {pythonDLL}");
 
                 // Set the python DLL
                 Runtime.PythonDLL = pythonDLL;
@@ -137,34 +139,42 @@ namespace Bonsai.Scripting.Python
                 // Only set environment/python.net variables if a virtual environment is used, otherwise use default python configuration
                 if (!string.IsNullOrEmpty(path))
                 {
-                    var pathToVirtualEnv = Path.GetFullPath(path);
+                    // var pathToVirtualEnv = Path.GetFullPath(path);
                     // Console.WriteLine($"Venv path: {pathToVirtualEnv}");
 
-                    if (string.IsNullOrEmpty(venvPath))
+                    // if (string.IsNullOrEmpty(venvPath))
+                    // {
+                    //     Environment.SetEnvironmentVariable("VIRTUAL_ENV", pathToVirtualEnv);
+                    //     // var virtualEnvPrompt = $"({Path.GetFileName(pathToVirtualEnv)})";
+                    //     // Environment.SetEnvironmentVariable("VIRTUAL_ENV_PROMPT", virtualEnvPrompt);
+                    //     // var ps1 = Environment.GetEnvironmentVariable("PS1");
+                    //     // ps1 = string.IsNullOrEmpty(ps1) ? virtualEnvPrompt : virtualEnvPrompt + " " + ps1;
+                    //     // Environment.SetEnvironmentVariable("PS1", ps1);
+                    // }
+                    EnvironmentHelper.SetRuntimePath(pythonHome, path, pythonVersion);
+                    PythonEngine.PythonHome = pythonHome;
+                    // string systemPath = Environment.GetEnvironmentVariable("PATH")!.TrimEnd(Path.PathSeparator);
+                    // systemPath = string.IsNullOrEmpty(systemPath) ? $"{pathToVirtualEnv}/bin" : $"{pathToVirtualEnv}/bin" + Path.PathSeparator + systemPath;
+                    // Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
+                    // Environment.SetEnvironmentVariable("PYTHONHOME", pathToVirtualEnv, EnvironmentVariableTarget.Process);
+                    // var pythonBase = Path.GetDirectoryName(pythonHome);
+                    // Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(Path.PathSeparator.ToString(),
+                    //     pathToVirtualEnv,
+                    //     $"{pythonBase}/lib/python{pythonVersion}.zip",
+                    //     $"{pythonBase}/lib/python{pythonVersion}",
+                    //     $"{pythonBase}/lib/python{pythonVersion}/lib-dynload",
+                    //     $"{pathToVirtualEnv}/lib/python{pythonVersion}/site-packages"), EnvironmentVariableTarget.Process);
+
+                    if (pythonHome != path)
                     {
-                        Environment.SetEnvironmentVariable("VIRTUAL_ENV", pathToVirtualEnv);
-                        var virtualEnvPrompt = $"({Path.GetFileName(pathToVirtualEnv)})";
-                        Environment.SetEnvironmentVariable("VIRTUAL_ENV_PROMPT", virtualEnvPrompt);
-                        var ps1 = Environment.GetEnvironmentVariable("PS1");
-                        ps1 = string.IsNullOrEmpty(ps1) ? virtualEnvPrompt : virtualEnvPrompt + " " + ps1;
-                        Environment.SetEnvironmentVariable("PS1", ps1);
+                        var basePath = PythonEngine.PythonPath;
+                        var pythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path, basePath, pythonDLL);
+                        // PythonEngine.PythonPath = PythonEngine.PythonPath + Path.PathSeparator +
+                        //     Environment.GetEnvironmentVariable("PYTHONPATH", EnvironmentVariableTarget.Process);
+                        PythonEngine.PythonPath = pythonPath;
                     }
-
-                    string systemPath = Environment.GetEnvironmentVariable("PATH")!.TrimEnd(Path.PathSeparator);
-                    systemPath = string.IsNullOrEmpty(systemPath) ? $"{pathToVirtualEnv}/bin" : $"{pathToVirtualEnv}/bin" + Path.PathSeparator + systemPath;
-                    Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
-                    Environment.SetEnvironmentVariable("PYTHONHOME", pathToVirtualEnv, EnvironmentVariableTarget.Process);
-                    var pythonBase = Path.GetDirectoryName(pythonHome);
-                    Environment.SetEnvironmentVariable("PYTHONPATH", string.Join(Path.PathSeparator.ToString(),
-                        pathToVirtualEnv,
-                        $"{pythonBase}/lib/python{pythonVersion}.zip",
-                        $"{pythonBase}/lib/python{pythonVersion}",
-                        $"{pythonBase}/lib/python{pythonVersion}/lib-dynload",
-                        $"{pathToVirtualEnv}/lib/python{pythonVersion}/site-packages"), EnvironmentVariableTarget.Process);
-
-                    PythonEngine.PythonPath = PythonEngine.PythonPath + Path.PathSeparator +
-                                            Environment.GetEnvironmentVariable("PYTHONPATH", EnvironmentVariableTarget.Process);
-                    PythonEngine.PythonHome = pathToVirtualEnv;
+                    // PythonEngine.PythonHome = path;
+                    // PythonEngine.PythonHome = pythonHome;
                 }
 
                 PythonEngine.Initialize();

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -103,13 +103,13 @@ namespace Bonsai.Scripting.Python
                 Console.WriteLine($"Python DLL: {pythonDLL}");
                 Runtime.PythonDLL = pythonDLL;
 
-                // var systemPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
-                // if (!systemPath.Split(Path.PathSeparator).Contains(pythonHome, StringComparer.OrdinalIgnoreCase))
-                // {
-                //     systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + path;
-                // }
-                // Console.WriteLine($"System Path: {systemPath}");
-                // Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
+                var systemPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
+                if (!systemPath.Split(Path.PathSeparator).Contains(pythonHome, StringComparer.OrdinalIgnoreCase))
+                {
+                    systemPath = string.IsNullOrEmpty(systemPath) ? pythonHome : pythonHome + Path.PathSeparator + path;
+                }
+                Console.WriteLine($"System Path: {systemPath}");
+                Environment.SetEnvironmentVariable("PATH", systemPath, EnvironmentVariableTarget.Process);
 
                 PythonEngine.PythonHome = pythonHome;
 


### PR DESCRIPTION
This PR adds the following features:

1. Support for Linux OS - previously, the way the RuntimeManager and EnvironmentHelper configured the path variables and python engine were hard-coded and specific to the Windows OS. I have added several lines of code in both of these which will 1) determine the current OS; and 2) configure path and python engine based on the OS detected.
2. Support for global python installations - previously, if no virtual environment was detected, then creation of the python engine would fail due to incorrect loading of the python DLL. With the newly added features, the EnvironmentHelper will search for a global python installation by performing a directory search through the path and correctly set the python DLL if a python installation on the path has been detected.
3. Support for loading python scripts in assembly - when using the CreateRuntime module in Bonsai, it is now possible for the RuntimeManager to parse the path of a script to determine 1) if it is an embedded resource; and 2) load the embedded python from the specified assembly location.