### PR TITLE
Add support for linux and system site packages

### DIFF
--- a/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
+++ b/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.7.0" />
-    <PackageReference Include="pythonnet" Version="3.0.1" />
+    <PackageReference Include="pythonnet" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
@@ -13,6 +13,7 @@ namespace Bonsai.Scripting.Python
             Path = pythonHome;
             PythonHome = pythonHome;
             PythonVersion = pythonVersion;
+            IncludeSystemSitePackages = true;
         }
 
         public string Path { get; private set; }
@@ -20,6 +21,8 @@ namespace Bonsai.Scripting.Python
         public string PythonHome { get; private set; }
 
         public string PythonVersion { get; private set; }
+
+        public bool IncludeSystemSitePackages { get; private set; }
 
         public static EnvironmentConfig FromConfigFile(string configFileName)
         {
@@ -38,6 +41,10 @@ namespace Bonsai.Scripting.Python
                 if (line.StartsWith("home"))
                 {
                     config.PythonHome = GetConfigValue(line);
+                }
+                else if (line.StartsWith("include-system-site-packages"))
+                {
+                    config.IncludeSystemSitePackages = bool.Parse(GetConfigValue(line));
                 }
                 else if (line.StartsWith("version"))
                 {

--- a/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
@@ -1,0 +1,56 @@
+﻿using System.IO;
+
+namespace Bonsai.Scripting.Python
+{
+    internal class EnvironmentConfig
+    {
+        private EnvironmentConfig()
+        {
+        }
+
+        public EnvironmentConfig(string pythonHome, string pythonVersion)
+        {
+            Path = pythonHome;
+            PythonHome = pythonHome;
+            PythonVersion = pythonVersion;
+        }
+
+        public string Path { get; private set; }
+
+        public string PythonHome { get; private set; }
+
+        public string PythonVersion { get; private set; }
+
+        public static EnvironmentConfig FromConfigFile(string configFileName)
+        {
+            var config = new EnvironmentConfig();
+            config.Path = System.IO.Path.GetDirectoryName(configFileName);
+            using var configReader = new StreamReader(File.OpenRead(configFileName));
+            while (!configReader.EndOfStream)
+            {
+                var line = configReader.ReadLine();
+                static string GetConfigValue(string line)
+                {
+                    var parts = line.Split('=');
+                    return parts.Length > 1 ? parts[1].Trim() : string.Empty;
+                }
+
+                if (line.StartsWith("home"))
+                {
+                    config.PythonHome = GetConfigValue(line);
+                }
+                else if (line.StartsWith("version"))
+                {
+                    var pythonVersion = GetConfigValue(line);
+                    if (!string.IsNullOrEmpty(pythonVersion))
+                    {
+                        pythonVersion = pythonVersion.Substring(0, pythonVersion.LastIndexOf('.'));
+                    }
+                    config.PythonVersion = pythonVersion;
+                }
+            }
+
+            return config;
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -80,6 +80,11 @@ namespace Bonsai.Scripting.Python
                 }
 
                 sitePackages = Path.Combine(config.Path, "Lib", "site-packages");
+                if (config.IncludeSystemSitePackages && config.Path != config.PythonHome)
+                {
+                    var systemSitePackages = Path.Combine(config.PythonHome, "Lib", "site-packages");
+                    sitePackages = $"{sitePackages}{Path.PathSeparator}{systemSitePackages}";
+                }
             }
             else
             {
@@ -92,6 +97,13 @@ namespace Bonsai.Scripting.Python
                 }
 
                 sitePackages = Path.Combine(config.Path, "lib", $"python{config.PythonVersion}", "site-packages");
+                if (config.IncludeSystemSitePackages)
+                {
+                    var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                    var localFolder = Directory.GetParent(localAppData).FullName;
+                    var systemSitePackages = Path.Combine(localFolder, "lib", $"python{config.PythonVersion}", "site-packages");
+                    sitePackages = $"{sitePackages}{Path.PathSeparator}{systemSitePackages}";
+                }
             }
 
             return $"{basePath}{Path.PathSeparator}{config.Path}{Path.PathSeparator}{sitePackages}";

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -1,31 +1,44 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
+using System.Runtime.InteropServices;
 using Python.Runtime;
 
 namespace Bonsai.Scripting.Python
 {
     static class EnvironmentHelper
     {
-        public static string GetPythonDLL(string path)
+        public static string GetPythonDLL(string pythonVersion)
         {
-            return Directory
-                .EnumerateFiles(path, searchPattern: "python3?*.*")
-                .Select(Path.GetFileNameWithoutExtension)
-                .Where(match => match.Length > "python3".Length)
-                .Select(match => match.Replace(".", string.Empty))
-                .FirstOrDefault();
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? $"python{pythonVersion.Replace(".", string.Empty)}.dll"
+                : $"libpython{pythonVersion}.so";
         }
 
         public static void SetRuntimePath(string pythonHome)
         {
-            var path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
-            path = string.IsNullOrEmpty(path) ? pythonHome : pythonHome + Path.PathSeparator + path;
-            Environment.SetEnvironmentVariable("PATH", path, EnvironmentVariableTarget.Process);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process).TrimEnd(Path.PathSeparator);
+                path = string.IsNullOrEmpty(path) ? pythonHome : pythonHome + Path.PathSeparator + path;
+                Environment.SetEnvironmentVariable("PATH", path, EnvironmentVariableTarget.Process);
+            }
         }
 
-        public static string GetPythonHome(string path)
+        public static string GetVirtualEnvironmentPath(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                path = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
+                if (path == null) return path;
+            }
+
+            return Path.GetFullPath(path);
+        }
+
+        public static string GetPythonHome(string path, out string pythonVersion)
+        {
+            var pythonHome = path;
+            pythonVersion = string.Empty;
             var configFileName = Path.Combine(path, "pyvenv.cfg");
             if (File.Exists(configFileName))
             {
@@ -33,30 +46,60 @@ namespace Bonsai.Scripting.Python
                 while (!configReader.EndOfStream)
                 {
                     var line = configReader.ReadLine();
-                    if (line.StartsWith("home"))
+                    static string GetConfigValue(string line)
                     {
                         var parts = line.Split('=');
-                        return parts[parts.Length - 1].Trim();
+                        return parts.Length > 1 ? parts[1].Trim() : string.Empty;
+                    }
+
+                    if (line.StartsWith("home"))
+                    {
+                        pythonHome = GetConfigValue(line);
+                    }
+                    else if (line.StartsWith("version"))
+                    {
+                        pythonVersion = GetConfigValue(line);
+                        if (!string.IsNullOrEmpty(pythonVersion))
+                        {
+                            pythonVersion = pythonVersion.Substring(0, pythonVersion.LastIndexOf('.'));
+                        }
                     }
                 }
             }
 
-            return path;
+            return pythonHome;
         }
 
-        public static string GetPythonPath(string pythonHome, string path)
+        public static string GetPythonPath(string pythonHome, string pythonVersion, string path)
         {
+            string sitePackages;
             var basePath = PythonEngine.PythonPath;
-            if (string.IsNullOrEmpty(basePath))
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var pythonZip = Path.Combine(pythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
-                var pythonDLLs = Path.Combine(pythonHome, "DLLs");
-                var pythonLib = Path.Combine(pythonHome, "Lib");
-                var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
+                if (string.IsNullOrEmpty(basePath))
+                {
+                    var pythonZip = Path.Combine(pythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
+                    var pythonDLLs = Path.Combine(pythonHome, "DLLs");
+                    var pythonLib = Path.Combine(pythonHome, "Lib");
+                    basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
+                }
+
+                sitePackages = Path.Combine(path, "Lib", "site-packages");
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(basePath))
+                {
+                    var pythonBase = Path.GetDirectoryName(pythonHome);
+                    pythonBase = Path.Combine(pythonBase, "lib", $"python{pythonVersion}");
+                    var pythonLibDynload = Path.Combine(pythonBase, "lib-dynload");
+                    basePath = string.Join(Path.PathSeparator.ToString(), pythonBase, pythonLibDynload, baseDirectory);
+                }
+
+                sitePackages = Path.Combine(path, "lib", $"python{pythonVersion}", "site-packages");
             }
 
-            var sitePackages = Path.Combine(path, "Lib", "site-packages");
             return $"{basePath}{Path.PathSeparator}{path}{Path.PathSeparator}{sitePackages}";
         }
     }

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -92,18 +92,15 @@ namespace Bonsai.Scripting.Python
 
         public static string GetPythonPath(EnvironmentConfig config)
         {
+            string basePath;
             string sitePackages;
-            var basePath = PythonEngine.PythonPath;
             var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (string.IsNullOrEmpty(basePath))
-                {
-                    var pythonZip = Path.Combine(config.PythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
-                    var pythonDLLs = Path.Combine(config.PythonHome, "DLLs");
-                    var pythonLib = Path.Combine(config.PythonHome, "Lib");
-                    basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
-                }
+                var pythonZip = Path.Combine(config.PythonHome, Path.ChangeExtension(Runtime.PythonDLL, ".zip"));
+                var pythonDLLs = Path.Combine(config.PythonHome, "DLLs");
+                var pythonLib = Path.Combine(config.PythonHome, "Lib");
+                basePath = string.Join(Path.PathSeparator.ToString(), pythonZip, pythonDLLs, pythonLib, baseDirectory);
 
                 sitePackages = Path.Combine(config.Path, "Lib", "site-packages");
                 if (config.IncludeSystemSitePackages && config.Path != config.PythonHome)
@@ -114,13 +111,10 @@ namespace Bonsai.Scripting.Python
             }
             else
             {
-                if (string.IsNullOrEmpty(basePath))
-                {
-                    var pythonBase = Path.GetDirectoryName(config.PythonHome);
-                    pythonBase = Path.Combine(pythonBase, "lib", $"python{config.PythonVersion}");
-                    var pythonLibDynload = Path.Combine(pythonBase, "lib-dynload");
-                    basePath = string.Join(Path.PathSeparator.ToString(), pythonBase, pythonLibDynload, baseDirectory);
-                }
+                var pythonBase = Path.GetDirectoryName(config.PythonHome);
+                pythonBase = Path.Combine(pythonBase, "lib", $"python{config.PythonVersion}");
+                var pythonLibDynload = Path.Combine(pythonBase, "lib-dynload");
+                basePath = string.Join(Path.PathSeparator.ToString(), pythonBase, pythonLibDynload, baseDirectory);
 
                 sitePackages = Path.Combine(config.Path, "lib", $"python{config.PythonVersion}", "site-packages");
                 if (config.IncludeSystemSitePackages)

--- a/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentHelper.cs
@@ -51,10 +51,14 @@ namespace Bonsai.Scripting.Python
             if (string.IsNullOrEmpty(path))
             {
                 path = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                if (path == null) return FindPythonHome();
+                path ??= FindPythonHome();
+            }
+            else
+            {
+                path = Path.GetFullPath(path);
             }
 
-            return Path.GetFullPath(path);
+            return PathHelper.TrimEndingDirectorySeparator(path);
         }
 
         public static EnvironmentConfig GetEnvironmentConfig(string path)

--- a/src/Bonsai.Scripting.Python/MonoHelper.cs
+++ b/src/Bonsai.Scripting.Python/MonoHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Bonsai.Scripting.Python
+{
+    static class MonoHelper
+    {
+        internal static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
+
+        public static string GetRealPath(string path)
+        {
+            var unixPath = Type.GetType("Mono.Unix.UnixPath, Mono.Posix");
+            if (unixPath == null)
+            {
+                throw new InvalidOperationException("No compatible Mono.Posix implementation was found.");
+            }
+
+            var getRealPath = unixPath.GetMethod(nameof(GetRealPath));
+            if (getRealPath == null)
+            {
+                throw new InvalidOperationException($"No compatible {nameof(GetRealPath)} method was found.");
+            }
+
+            return (string)getRealPath.Invoke(null, new[] { path });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/PathHelper.cs
+++ b/src/Bonsai.Scripting.Python/PathHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace Bonsai.Scripting.Python
+{
+    static class PathHelper
+    {
+        static bool IsDirectorySeparator(char c)
+        {
+            return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+        }
+
+        static bool IsRoot(string path)
+        {
+            return !string.IsNullOrEmpty(path) &&
+                    Path.IsPathRooted(path) &&
+                    path.Length == Path.GetPathRoot(path).Length;
+        }
+
+        internal static string TrimEndingDirectorySeparator(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && IsDirectorySeparator(path[path.Length - 1]) && !IsRoot(path))
+            {
+                path = path.Substring(0, path.Length - 1);
+            }
+
+            return path;
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -115,15 +115,15 @@ namespace Bonsai.Scripting.Python
         {
             if (!PythonEngine.IsInitialized)
             {
-                path = EnvironmentHelper.GetVirtualEnvironmentPath(path);
-                var pythonHome = EnvironmentHelper.GetPythonHome(path, out string pythonVersion);
-                Runtime.PythonDLL = EnvironmentHelper.GetPythonDLL(pythonVersion);
-                EnvironmentHelper.SetRuntimePath(pythonHome);
-                PythonEngine.PythonHome = pythonHome;
-                if (pythonHome != path)
+                path = EnvironmentHelper.GetEnvironmentPath(path);
+                var config = EnvironmentHelper.GetEnvironmentConfig(path);
+                Runtime.PythonDLL = EnvironmentHelper.GetPythonDLL(config);
+                EnvironmentHelper.SetRuntimePath(config.PythonHome);
+                PythonEngine.PythonHome = config.PythonHome;
+                if (config.PythonHome != path)
                 {
                     var version = PythonEngine.Version;
-                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, pythonVersion, path);
+                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(config);
                 }
                 PythonEngine.Initialize();
             }

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -115,21 +115,15 @@ namespace Bonsai.Scripting.Python
         {
             if (!PythonEngine.IsInitialized)
             {
-                if (string.IsNullOrEmpty(path))
-                {
-                    path = Environment.GetEnvironmentVariable("VIRTUAL_ENV", EnvironmentVariableTarget.Process);
-                    if (string.IsNullOrEmpty(path)) path = Environment.CurrentDirectory;
-                }
-
-                path = Path.GetFullPath(path);
-                var pythonHome = EnvironmentHelper.GetPythonHome(path);
-                Runtime.PythonDLL = EnvironmentHelper.GetPythonDLL(pythonHome);
+                path = EnvironmentHelper.GetVirtualEnvironmentPath(path);
+                var pythonHome = EnvironmentHelper.GetPythonHome(path, out string pythonVersion);
+                Runtime.PythonDLL = EnvironmentHelper.GetPythonDLL(pythonVersion);
                 EnvironmentHelper.SetRuntimePath(pythonHome);
                 PythonEngine.PythonHome = pythonHome;
                 if (pythonHome != path)
                 {
                     var version = PythonEngine.Version;
-                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, path);
+                    PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(pythonHome, pythonVersion, path);
                 }
                 PythonEngine.Initialize();
             }


### PR DESCRIPTION
There were issues with python library detection and path configuration preventing the package from running on standard Linux distributions. This PR addresses these limitations by generalizing detection of the python native library and environment configuration to support both Windows and Linux. Support for detecting the default system python and including system site packages in virtual environments was also added.

The current detection strategy depends on `libpython-dev` being installed on the system. Instructions for running on Linux should probably be added or updated in the documentation.