### PR TITLE
Add operator to ensure notifications are emitted inside the GIL

### DIFF
--- a/src/Bonsai.Scripting.Python/CreateModule.cs
+++ b/src/Bonsai.Scripting.Python/CreateModule.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.IO;
 using System.Reactive.Linq;
 using Python.Runtime;
 
@@ -34,11 +33,11 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyModule> Generate()
         {
-            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
-            {
-                var module = RuntimeManager.CreateModule(Name ?? string.Empty, ScriptPath);
-                return Observable.Return(module);
-            });
+            var name = Name;
+            var scriptPath = ScriptPath;
+            return RuntimeManager.RuntimeSource
+                .ObserveOnGIL()
+                .Select(_ => RuntimeManager.CreateModule(name ?? string.Empty, scriptPath));
         }
     }
 }

--- a/src/Bonsai.Scripting.Python/Eval.cs
+++ b/src/Bonsai.Scripting.Python/Eval.cs
@@ -44,17 +44,9 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyObject> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
-            {
-                return source.Select(_ =>
-                {
-                    using (Py.GIL())
-                    {
-                        var module = Module ?? runtime.MainModule;
-                        return module.Eval(Expression);
-                    }
-                });
-            });
+            return RuntimeManager.RuntimeSource
+                .GetModuleOrDefaultAsync(Module)
+                .SelectMany(module => source.Select(_ => module.Eval(Expression)));
         }
 
         /// <summary>
@@ -69,13 +61,7 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public IObservable<PyObject> Process(IObservable<PyModule> source)
         {
-            return source.Select(module =>
-            {
-                using (Py.GIL())
-                {
-                    return module.Eval(Expression);
-                }
-            });
+            return source.Select(module => module.Eval(Expression));
         }
 
         /// <summary>
@@ -90,13 +76,7 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public IObservable<PyObject> Process(IObservable<RuntimeManager> source)
         {
-            return source.Select(runtime =>
-            {
-                using (Py.GIL())
-                {
-                    return runtime.MainModule.Eval(Expression);
-                }
-            });
+            return source.Select(runtime => runtime.MainModule.Eval(Expression));
         }
     }
 }

--- a/src/Bonsai.Scripting.Python/Exec.cs
+++ b/src/Bonsai.Scripting.Python/Exec.cs
@@ -45,17 +45,9 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyModule> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
-            {
-                return source.Select(_ =>
-                {
-                    using (Py.GIL())
-                    {
-                        var module = Module ?? runtime.MainModule;
-                        return module.Exec(Script);
-                    }
-                });
-            });
+            return RuntimeManager.RuntimeSource
+                .GetModuleOrDefaultAsync(Module)
+                .SelectMany(module => source.Select(_ => module.Exec(Script)));
         }
 
         /// <summary>
@@ -71,13 +63,7 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public IObservable<PyModule> Process(IObservable<PyModule> source)
         {
-            return source.Select(module =>
-            {
-                using (Py.GIL())
-                {
-                    return module.Exec(Script);
-                }
-            });
+            return source.Select(module => module.Exec(Script));
         }
 
         /// <summary>
@@ -92,13 +78,7 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public IObservable<PyModule> Process(IObservable<RuntimeManager> source)
         {
-            return source.Select(runtime =>
-            {
-                using (Py.GIL())
-                {
-                    return runtime.MainModule.Exec(Script);
-                }
-            });
+            return source.Select(runtime => runtime.MainModule.Exec(Script));
         }
     }
 }

--- a/src/Bonsai.Scripting.Python/GetRuntime.cs
+++ b/src/Bonsai.Scripting.Python/GetRuntime.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Bonsai.Scripting.Python
+{
+    /// <summary>
+    /// Represents an operator that gets the Python runtime object which can be used
+    /// to import modules, evaluate expressions, and pass data to and from Python.
+    /// </summary>
+    /// <remarks>
+    /// The runtime object notification is emitted while holding the global interpreter lock.
+    /// </remarks>
+    [Description("Gets the Python runtime object which can be used to import modules, evaluate expressions, and pass data to and from Python.")]
+    public class GetRuntime : Source<RuntimeManager>
+    {
+        /// <summary>
+        /// Wraps an observable sequence to ensure all notifications are emitted
+        /// while holding the Python global interpreter lock.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence that returns the active <see cref="RuntimeManager"/>
+        /// object on subscription. The value is emitted while holding the global
+        /// interpreter lock.
+        /// </returns>
+        public override IObservable<RuntimeManager> Generate()
+        {
+            return RuntimeManager.RuntimeSource.ObserveOnGIL();
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/ObservableExtensions.cs
+++ b/src/Bonsai.Scripting.Python/ObservableExtensions.cs
@@ -7,6 +7,13 @@ namespace Bonsai.Scripting.Python
 {
     static class ObservableExtensions
     {
+        public static IObservable<PyModule> GetModuleOrDefaultAsync(this IObservable<RuntimeManager> source, PyModule module)
+        {
+            return module != null
+                ? Observable.Return(module)
+                : source.Select(runtime => runtime.MainModule);
+        }
+
         public static IObservable<TSource> ObserveOnGIL<TSource>(this IObservable<TSource> source)
         {
             return Observable.Create<TSource>(observer =>

--- a/src/Bonsai.Scripting.Python/ObservableExtensions.cs
+++ b/src/Bonsai.Scripting.Python/ObservableExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using Python.Runtime;
+
+namespace Bonsai.Scripting.Python
+{
+    static class ObservableExtensions
+    {
+        public static IObservable<TSource> ObserveOnGIL<TSource>(this IObservable<TSource> source)
+        {
+            return Observable.Create<TSource>(observer =>
+            {
+                var sourceObserver = Observer.Create<TSource>(
+                    value =>
+                    {
+                        using (Py.GIL())
+                        {
+                            observer.OnNext(value);
+                        }
+                    },
+                    observer.OnError,
+                    observer.OnCompleted);
+                return source.SubscribeSafe(sourceObserver);
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/ObserveOnGIL.cs
+++ b/src/Bonsai.Scripting.Python/ObserveOnGIL.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    /// <summary>
+    /// Represents an operator that wraps the source sequence to ensure all notifications
+    /// are emitted while holding the Python global interpreter lock.
+    /// </summary>
+    [Description("Wraps the source sequence to ensure all notifications are emitted while holding the Python global interpreter lock.")]
+    public class ObserveOnGIL : Combinator
+    {
+        /// <summary>
+        /// Wraps an observable sequence to ensure all notifications are emitted
+        /// while holding the Python global interpreter lock.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">The source sequence to wrap.</param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of ensuring that
+        /// all notifications are emitted inside the Python global interpreter lock.
+        /// </returns>
+        public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return RuntimeManager.RuntimeSource.SelectMany(_ => source.ObserveOnGIL());
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -31,8 +31,8 @@ namespace Bonsai.Scripting.Python
                 using (Py.GIL())
                 {
                     MainModule = CreateModule(scriptPath: scriptPath);
+                    observer.OnNext(this);
                 }
-                observer.OnNext(this);
             });
         }
 
@@ -79,24 +79,21 @@ namespace Bonsai.Scripting.Python
 
         internal static DynamicModule CreateModule(string name = "", string scriptPath = "")
         {
-            using (Py.GIL())
+            var module = new DynamicModule(name);
+            if (!string.IsNullOrEmpty(scriptPath))
             {
-                var module = new DynamicModule(name);
-                if (!string.IsNullOrEmpty(scriptPath))
+                try
                 {
-                    try
-                    {
-                        var code = ReadAllText(scriptPath);
-                        module.Exec(code);
-                    }
-                    catch (Exception)
-                    {
-                        module.Dispose();
-                        throw;
-                    }
+                    var code = ReadAllText(scriptPath);
+                    module.Exec(code);
                 }
-                return module;
+                catch (Exception)
+                {
+                    module.Dispose();
+                    throw;
+                }
             }
+            return module;
         }
 
         internal void Schedule(Action action)

--- a/src/Bonsai.Scripting.Python/RuntimeManager.cs
+++ b/src/Bonsai.Scripting.Python/RuntimeManager.cs
@@ -122,7 +122,6 @@ namespace Bonsai.Scripting.Python
                 PythonEngine.PythonHome = config.PythonHome;
                 if (config.PythonHome != path)
                 {
-                    var version = PythonEngine.Version;
                     PythonEngine.PythonPath = EnvironmentHelper.GetPythonPath(config);
                 }
                 PythonEngine.Initialize();

--- a/src/Bonsai.Scripting.Python/Set.cs
+++ b/src/Bonsai.Scripting.Python/Set.cs
@@ -45,17 +45,9 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
-            {
-                return source.Do(value =>
-                {
-                    using (Py.GIL())
-                    {
-                        var module = Module ?? runtime.MainModule;
-                        module.Set(VariableName, value);
-                    }
-                });
-            });
+            return RuntimeManager.RuntimeSource
+                .GetModuleOrDefaultAsync(Module)
+                .SelectMany(module => source.Do(value => module.Set(VariableName, value)));
         }
     }
 }


### PR DESCRIPTION
This PR adds initial support for explicitly controlling the state of the global interpreter lock. In preparation for Python 3.12 sub-interpreters, we decided to remove implicit locking throughout the scripting library. This meant instead introducing support for locking and releasing the GIL.

Since we expect most scripting operations to be called in tandem with workflow notifications, it is enough to lock the GIL during the call to `OnNext`, which can be implemented as a general wrapper (`ObserveOnGIL`) around any observable sequence.

Finally, to minimize the need for explicit locking, this PR also moves emission of the runtime upon creation inside the GIL, so initialization operators can be chained directly without explicitly grabbing the interpreter lock. A new operator `GetRuntime` is also introduced to retrieve the runtime manager and re-emit it inside the GIL for deferred operations. This pattern may be generalized in the future to sub-interpreters or modules as necessary.

Fixes #10 