### PR TITLE
Operators to extend interactivity with python objects

### DIFF
--- a/src/Bonsai.Scripting.Python/Args.cs
+++ b/src/Bonsai.Scripting.Python/Args.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class Args
+    {
+        public IObservable<Pythonnet.PyTuple> Process(IObservable<object> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    if (!(obj is ITuple || obj is IList || obj is Array))
+                    {
+                        if (obj is Pythonnet.PyObject)
+                        {
+                            var pyObj = obj as Pythonnet.PyObject;
+                            return new Pythonnet.PyTuple(new Pythonnet.PyObject[] {pyObj});
+                        }
+                        
+                        return new Pythonnet.PyTuple(new Pythonnet.PyObject[] {Pythonnet.PyObject.FromManagedObject(obj)});
+                    }
+
+                    PropertyInfo[] properties = obj.GetType().GetProperties();
+                    Pythonnet.PyObject[] pyObjects = new Pythonnet.PyObject[properties.Length];
+
+                    for (int i = 0; i < properties.Length; i++)
+                    {
+                        object value = properties[i].GetValue(obj, null);
+
+                        if (!(value is Pythonnet.PyObject))
+                        {
+                            throw new ArgumentException($"All elements of the tuple must be of type PyObject. Instead, found {value.GetType()} for Item{i+1}.");
+                        }
+
+                        pyObjects[i] = (Pythonnet.PyObject)value;
+                    }
+                    return new Pythonnet.PyTuple(pyObjects);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
+++ b/src/Bonsai.Scripting.Python/EnvironmentConfig.cs
@@ -26,17 +26,14 @@ namespace Bonsai.Scripting.Python
 
         public static EnvironmentConfig FromConfigFile(string configFileName)
         {
-            var config = new EnvironmentConfig();
-            config.Path = System.IO.Path.GetDirectoryName(configFileName);
+            var config = new EnvironmentConfig
+            {
+                Path = System.IO.Path.GetDirectoryName(configFileName)
+            };
             using var configReader = new StreamReader(File.OpenRead(configFileName));
             while (!configReader.EndOfStream)
             {
                 var line = configReader.ReadLine();
-                static string GetConfigValue(string line)
-                {
-                    var parts = line.Split('=');
-                    return parts.Length > 1 ? parts[1].Trim() : string.Empty;
-                }
 
                 if (line.StartsWith("home"))
                 {
@@ -58,6 +55,12 @@ namespace Bonsai.Scripting.Python
             }
 
             return config;
+        }
+
+        private static string GetConfigValue(string line)
+        {
+            var parts = line.Split('=');
+            return parts.Length > 1 ? parts[1].Trim() : string.Empty;
         }
     }
 }

--- a/src/Bonsai.Scripting.Python/GetAttr.cs
+++ b/src/Bonsai.Scripting.Python/GetAttr.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class GetAttr
+    {
+        [Description("The name of the attribute to get.")]
+        public string Attribute { get; set; }
+
+        public IObservable<PyObject> Process(IObservable<PyObject> source)
+        {
+            if (string.IsNullOrEmpty(Attribute))
+            {
+                throw new Exception("Attribute cannot be null or empty.");
+            }
+            return source.Select(obj =>
+            {
+                using (Py.GIL())
+                {
+                    if (!obj.HasAttr(Attribute))
+                    {
+                        throw new Exception($"PyObject does not have attribute {Attribute}.");
+                    }
+                    return obj.GetAttr(Attribute);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/GetItem.cs
+++ b/src/Bonsai.Scripting.Python/GetItem.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class GetItem
+    {
+        [Description("The index to get.")]
+        public int? Index { get; set; } = null;
+
+        [Description("The key to get.")]
+        public string Key { get; set; } = null;
+
+        public IObservable<PyObject> Process(IObservable<PyObject> source)
+        {
+            if (!(Index.HasValue ^ !string.IsNullOrEmpty(Key)))
+            {
+                throw new Exception("Either an index or a key must be provided.");
+            }
+
+            return source.Select(obj =>
+            {
+                using (Py.GIL())
+                {
+                    if (!obj.IsIterable())
+                    {
+                        throw new Exception($"PyObject is not iterable.");
+                    }
+                    return Index != null ? obj.GetItem(Index.Value) : obj.GetItem(Key);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/GetPythonType.cs
+++ b/src/Bonsai.Scripting.Python/GetPythonType.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class GetPythonType
+    {
+
+        public IObservable<PyObject> Process(IObservable<PyObject> source)
+        {
+            return source.Select(obj => 
+            {
+                using (Py.GIL())
+                {
+                    return obj.GetPythonType();
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/Import.cs
+++ b/src/Bonsai.Scripting.Python/Import.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class Import
+    {
+        [Description("The name of the package.")]
+        public string Package { get; set; }
+
+        [Description("The \"as name\" of the package. For example, in \"import numpy as np\", np is the as name.")]
+        public string AsName { get; set; }
+
+        public IObservable<PyObject> Process(IObservable<PyModule> source)
+        {
+            if (string.IsNullOrEmpty(Package))
+            {
+                throw new ArgumentException(nameof(Package), "A package must be specified.");
+            }
+            return source.Select(module => 
+            {
+                using (Py.GIL())
+                {
+                    if (!string.IsNullOrEmpty(AsName))
+                    {
+                        return module.Import(Package, AsName);
+                    }
+
+                    if (!Package.Contains('.'))
+                    {
+                        return module.Import(Package);
+                    }
+
+                    var packages = Package.Split('.');
+                    var packagePath = string.Empty;
+
+                    PyObject obj = null;
+                    for (int i = 0; i < packages.Length; i++)
+                    {
+                        packagePath = string.IsNullOrEmpty(packagePath) ? packages[i] : $"{packagePath}.{packages[i]}";
+                        obj = module.Import(packagePath);
+                    }
+
+                    return obj;
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/Invoke.cs
+++ b/src/Bonsai.Scripting.Python/Invoke.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class Invoke
+    {
+        [Description("The name of the callable object to invoke.")]
+        public string Callable { get; set; }
+
+        [XmlIgnore]
+        [Description("The args to pass to the callable.")]
+        public Pythonnet.PyTuple Args { get; set; } = null;
+
+        public IObservable<Pythonnet.PyObject> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    var callable = string.IsNullOrEmpty(Callable) ? obj : obj.GetAttr(Callable);
+                    if (!callable.IsCallable())
+                    {
+                        throw new Exception($"Cannot invoke callable: {callable} because it is not callable.");
+                    }
+                    var args = Args == null ? new Pythonnet.PyTuple() : Args;
+                    return callable.Invoke(args);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/InvokeMethod.cs
+++ b/src/Bonsai.Scripting.Python/InvokeMethod.cs
@@ -1,0 +1,39 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class InvokeMethod
+    {
+        [Description("The name of the method to invoke.")]
+        public string Method { get; set; }
+
+        [XmlIgnore]
+        [Description("The args to pass to the callable.")]
+        public Pythonnet.PyTuple Args { get; set; } = null;
+
+        public IObservable<Pythonnet.PyObject> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            if (string.IsNullOrEmpty(Method))
+            {
+                throw new Exception("Method name cannot be null or empty.");
+            }
+
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    var args = Args == null ? new Pythonnet.PyTuple() : Args;
+                    return obj.InvokeMethod(Method, args);
+                }
+            });
+        }
+
+    }
+}

--- a/src/Bonsai.Scripting.Python/PyFloat.cs
+++ b/src/Bonsai.Scripting.Python/PyFloat.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class PyFloat
+    {
+
+        [Description("The value of the float.")]
+        public double Value { get; set; }
+
+        public IObservable<Pythonnet.PyFloat> Process()
+        {
+            return Observable.Defer(() =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return Observable.Return(new Pythonnet.PyFloat(Value));
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyFloat> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    if (!Pythonnet.PyNumber.IsNumberType(obj))
+                    {
+                        throw new ArgumentException("PyObject must be a type of number.");
+                    }
+                    return new Pythonnet.PyFloat(obj);
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyFloat> Process(IObservable<object> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return new Pythonnet.PyFloat(Value);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/PyInt.cs
+++ b/src/Bonsai.Scripting.Python/PyInt.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class PyInt
+    {
+
+        [Description("The value of the integer.")]
+        public int Value { get; set; }
+
+        public IObservable<Pythonnet.PyInt> Process()
+        {
+            return Observable.Defer(() =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return Observable.Return(new Pythonnet.PyInt(Value));
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyInt> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    if (!Pythonnet.PyNumber.IsNumberType(obj))
+                    {
+                        throw new ArgumentException("PyObject must be a type of number.");
+                    }
+                    return new Pythonnet.PyInt(obj);
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyInt> Process(IObservable<object> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return new Pythonnet.PyInt(Value);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/PyString.cs
+++ b/src/Bonsai.Scripting.Python/PyString.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class PyString
+    {
+
+        [Description("The value of the string.")]
+        public string Value { get; set; }
+
+        public IObservable<Pythonnet.PyString> Process()
+        {
+            return Observable.Defer(() =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return Observable.Return(new Pythonnet.PyString(Value));
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyString> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    if (!Pythonnet.PyString.IsStringType(obj))
+                    {
+                        throw new ArgumentException("PyObject must be a type of string.");
+                    }
+                    return new Pythonnet.PyString(obj);
+                }
+            });
+        }
+
+        public IObservable<Pythonnet.PyString> Process(IObservable<object> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    return new Pythonnet.PyString(Value);
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/PythonInterpreterLock.cs
+++ b/src/Bonsai.Scripting.Python/PythonInterpreterLock.cs
@@ -1,0 +1,67 @@
+using Bonsai.Expressions;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System;
+using System.Reflection;
+using System.Linq;
+using Python.Runtime;
+using System.Reactive;
+
+namespace Bonsai.Scripting.Python
+{
+    public class PythonInterpreterLock : WorkflowExpressionBuilder
+    {
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 1, upperBound: 1);
+        private static readonly object _lock = new object();
+
+        public PythonInterpreterLock()
+            : this(new ExpressionBuilderGraph())
+        {
+        }
+
+        public PythonInterpreterLock(ExpressionBuilderGraph workflow)
+            : base(workflow)
+        {
+        }
+
+        public override Range<int> ArgumentRange => argumentRange;
+
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.FirstOrDefault();
+            if (source == null)
+            {
+                throw new InvalidOperationException("There must be at least one input.");
+            }
+            var sourceType = source.Type.GetGenericArguments()[0];
+            var factoryParameter = Expression.Parameter(typeof(IObservable<>).MakeGenericType(sourceType), "factoryParam");
+
+            return BuildWorkflow(arguments, factoryParameter, selectorBody =>
+            {
+                var selector = Expression.Lambda(selectorBody, factoryParameter);
+                var resultType = selectorBody.Type.GetGenericArguments()[0];
+                return Expression.Call(GetType(), nameof(Process), new Type[] {sourceType, resultType}, source, selector);
+            });
+        }
+
+        static IObservable<TResult> Process<TSource, TResult>(IObservable<TSource> source, Func<IObservable<TSource>, IObservable<TResult>> selector)
+        {
+            return RuntimeManager.RuntimeSource.SelectMany(runtime => 
+            {
+                return selector(Observable.Create<TSource>(observer =>
+                {
+                    return source.SubscribeSafe(Observer.Create<TSource>(value =>
+                    {
+                        using (Py.GIL())
+                        {
+                            observer.OnNext(value); //locking around downstream effects
+                        }
+                    },
+                    observer.OnError,
+                    observer.OnCompleted));
+                }));
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/SetAttr.cs
+++ b/src/Bonsai.Scripting.Python/SetAttr.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class SetAttr
+    {
+        [Description("The name of the attribute to get.")]
+        public string Attribute { get; set; }
+
+        [XmlIgnore]
+        [Description("The object to assign to the attribute.")]
+        public PyObject Value { get; set; }
+
+        public IObservable<PyObject> Process(IObservable<PyObject> source)
+        {
+            if (string.IsNullOrEmpty(Attribute))
+            {
+                throw new Exception("Attribute cannot be null or empty.");
+            }
+            return source.Select(obj =>
+            {
+                using (Py.GIL())
+                {
+                    obj.SetAttr(Attribute, Value);
+                    return obj;
+                }
+            });
+        }
+    }
+}

--- a/src/Bonsai.Scripting.Python/SetItem.cs
+++ b/src/Bonsai.Scripting.Python/SetItem.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reactive.Linq;
+using Pythonnet = Python.Runtime;
+using System.Xml.Serialization;
+using System.Linq;
+
+namespace Bonsai.Scripting.Python
+{
+    [Combinator]
+    public class SetItem
+    {
+        [Description("The index to get.")]
+        public int Index { get; set; }
+
+        [XmlIgnore]
+        [Description("The value to assign to the item.")]
+        public Pythonnet.PyObject Value { get; set; }
+
+        public IObservable<Pythonnet.PyObject> Process(IObservable<Pythonnet.PyObject> source)
+        {
+            return source.Select(obj =>
+            {
+                using (Pythonnet.Py.GIL())
+                {
+                    if (!Pythonnet.PySequence.IsSequenceType(obj))
+                    {
+                        throw new Exception($"PyObject is not a type of sequence.");
+                    }
+                    obj.SetItem(Index, Value);
+                    return obj;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR is intended to add initial support for extended interactivity and manipulation of python objects outside of python scripting. Below are a few highlighted examples to demonstrate these new nodes.

**Basic python primitives**
Some nodes provide the ability to instantiate python primitives, such as `PyInt`, `PyFloat`, and `PyString`. This can be useful when all you want is to create a simple python object.
![Screenshot from 2024-03-04 12-35-32](https://github.com/bonsai-rx/python-scripting/assets/26148508/da72d545-0cca-469b-9b7c-f062cb3ae95d)

**Import**
It is also possible to use the `Import` function to import packages directly into a module without the need to script. For example, this would be the equivalent of using `import [python-package]` in a script.
![Screenshot from 2024-03-04 12-33-08](https://github.com/bonsai-rx/python-scripting/assets/26148508/403cbdf0-7f4e-4373-a758-06544a8bb2a4)

**Invoke**
`Invoke` can be used to instantiate a callable object. It can work directly on python objects to instantiate them or it can be used to invoke an attribute of the object. It supports passing `Args` to the invocation. For example, to achieve the equivalent python script `import numpy as np; arr = np.array([0])`, you can pass the np library object to `Invoke` and set the `Callable` property to `array`. Here is how that might look:
![Screenshot from 2024-03-04 14-28-14](https://github.com/bonsai-rx/python-scripting/assets/26148508/8bef217a-f6f6-4d09-9a38-28ea146d165f)

**InvokeMethod**
`InvokeMethod` can be used to call a method of an object. For example, if you wanted to use the `transpose` method of a numpy array, you can pass you numpy array object to `InvokeMethod` and specify transpose as the method. In our example, this would be the equivalent of doing `arr.transpose()`. 

**GetAttr**
The `GetAttr` method can be used to access an attribute of a python object. For example, instead of calling the `transpose` function of the numpy array, you could call `GetAttr` with `Attribute` set to `T`, which is the equivalent of doing `arr.T` in our example.