### PR TITLE
Ensure module caching follows runtime creation

### DIFF
--- a/src/Bonsai.Scripting.Python/Eval.cs
+++ b/src/Bonsai.Scripting.Python/Eval.cs
@@ -44,9 +44,11 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyObject> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource
-                .GetModuleOrDefaultAsync(Module)
-                .SelectMany(module => source.Select(_ => module.Eval(Expression)));
+            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
+            {
+                var module = Module ?? runtime.MainModule;
+                return source.Select(_ => module.Eval(Expression));
+            });
         }
 
         /// <summary>

--- a/src/Bonsai.Scripting.Python/Exec.cs
+++ b/src/Bonsai.Scripting.Python/Exec.cs
@@ -45,9 +45,11 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyModule> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource
-                .GetModuleOrDefaultAsync(Module)
-                .SelectMany(module => source.Select(_ => module.Exec(Script)));
+            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
+            {
+                var module = Module ?? runtime.MainModule;
+                return source.Select(_ => module.Exec(Script));
+            });
         }
 
         /// <summary>

--- a/src/Bonsai.Scripting.Python/Get.cs
+++ b/src/Bonsai.Scripting.Python/Get.cs
@@ -38,10 +38,9 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<PyObject> Generate()
         {
-            return RuntimeManager.RuntimeSource
-                .GetModuleOrDefaultAsync(Module)
-                .ObserveOnGIL()
-                .Select(module => module.Get(VariableName));
+            return from runtime in RuntimeManager.RuntimeSource.ObserveOnGIL()
+                   let module = Module ?? runtime.MainModule
+                   select module.Get(VariableName);
         }
 
         /// <summary>
@@ -60,9 +59,11 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public IObservable<PyObject> Generate<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource
-                .GetModuleOrDefaultAsync(Module)
-                .SelectMany(module => source.Select(_ => module.Get(VariableName)));
+            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
+            {
+                var module = Module ?? runtime.MainModule;
+                return source.Select(_ => module.Get(VariableName));
+            });
         }
 
         /// <summary>

--- a/src/Bonsai.Scripting.Python/ObservableExtensions.cs
+++ b/src/Bonsai.Scripting.Python/ObservableExtensions.cs
@@ -7,13 +7,6 @@ namespace Bonsai.Scripting.Python
 {
     static class ObservableExtensions
     {
-        public static IObservable<PyModule> GetModuleOrDefaultAsync(this IObservable<RuntimeManager> source, PyModule module)
-        {
-            return module != null
-                ? Observable.Return(module)
-                : source.Select(runtime => runtime.MainModule);
-        }
-
         public static IObservable<TSource> ObserveOnGIL<TSource>(this IObservable<TSource> source)
         {
             return Observable.Create<TSource>(observer =>

--- a/src/Bonsai.Scripting.Python/Set.cs
+++ b/src/Bonsai.Scripting.Python/Set.cs
@@ -45,9 +45,11 @@ namespace Bonsai.Scripting.Python
         /// </returns>
         public override IObservable<TSource> Process<TSource>(IObservable<TSource> source)
         {
-            return RuntimeManager.RuntimeSource
-                .GetModuleOrDefaultAsync(Module)
-                .SelectMany(module => source.Do(value => module.Set(VariableName, value)));
+            return RuntimeManager.RuntimeSource.SelectMany(runtime =>
+            {
+                var module = Module ?? runtime.MainModule;
+                return source.Do(value => module.Set(VariableName, value));
+            });
         }
     }
 }


### PR DESCRIPTION
This PR ensures module caching is not done prematurely, since module creation requires the Python runtime to be initialized. This could cause unexpected race conditions when dynamically initializing module properties.