### PR TITLE
Updated `pythonnet` package dependency version to latest

### DIFF
--- a/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
+++ b/src/Bonsai.Scripting.Python/Bonsai.Scripting.Python.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.7.0" />
-    <PackageReference Include="pythonnet" Version="3.0.3" />
+    <PackageReference Include="pythonnet" Version="3.0.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The current version of `pythonnet` does not support the latest version of Python, which is now Python 3.13, so we update `pythonnet` to the latest version (version `3.0.5`).

Fixes #25 